### PR TITLE
Deploy Application Insights to resource group region

### DIFF
--- a/arm/ArmDeploy/azuredeploy.json
+++ b/arm/ArmDeploy/azuredeploy.json
@@ -185,7 +185,7 @@
       "apiVersion": "2014-04-01",
       "name": "[variables('appInsightsName')]",
       "type": "Microsoft.Insights/components",
-      "location": "East US",
+      "location": "[resourceGroup().location]",
       "tags": {
         "[concat('hidden-link:', resourceGroup().id, '/providers/Microsoft.Web/sites/', parameters('webSiteName'))]": "Resource",
         "displayName": "AppInsightsComponent"


### PR DESCRIPTION
Value used to be hard coded to `East US` region. Now uses whatever was intended for the rest of the resource group.